### PR TITLE
fieldmanual works when sphinx-build binary is not on PATH

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -17,7 +17,7 @@ plugin_root = pathlib.Path('plugins/%s' % (name,))
 sphinx_docs_root = plugin_root / 'sphinx-docs'
 html_docs_root = sphinx_docs_root / '_build' / 'html'
 
-logger = logging.getLogger("fieldmanual")
+logger = logging.getLogger('fieldmanual')
 
 
 async def landing(_):
@@ -52,12 +52,12 @@ async def build_docs(loop=None):
         except Exception:
             logger.warning("Encountered problem while building documentation.", exc_info=True)
 
-        if "build succeeded" in out and err:
-            logger.info("Docs built successfully with the following warnings\n%s" % err)
-        elif "build succeeded" in out:
-            logger.info("Docs built successfully.")
+        if 'build succeeded' in out and err:
+            logger.info('Docs built successfully with the following warnings\n%s' % err)
+        elif 'build succeeded' in out:
+            logger.info('Docs built successfully.')
         else:
-            logger.warning("Unable to build docs:\n%s" % err)
+            logger.warning('Unable to build docs:\n%s' % err)
 
 
 async def enable(services, loop=None):

--- a/hook.py
+++ b/hook.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import pathlib
 
+import concurrent.futures
 from aiohttp import web
 
 from app.utility.base_world import BaseWorld
@@ -16,25 +17,53 @@ plugin_root = pathlib.Path('plugins/%s' % (name,))
 sphinx_docs_root = plugin_root / 'sphinx-docs'
 html_docs_root = sphinx_docs_root / '_build' / 'html'
 
+logger = logging.getLogger("fieldmanual")
+
 
 async def landing(_):
     return web.FileResponse(str(plugin_root / 'static' / 'opener.html'))
 
 
-async def build_docs():
-    process = await asyncio.create_subprocess_exec(
-        'sphinx-build', '%s/' % (sphinx_docs_root,), str(html_docs_root), '-b', 'html', '-c', str(sphinx_docs_root),
-        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
-    stdout, stderr = await process.communicate()
-    logging.debug(stdout)
-    if process.returncode:
-        logging.error('doc generation failed: %s' % (stderr,))
+def _run_sphinx_build():
+    import sys
+    import io
+
+    import sphinx.cmd.build
+
+    out = io.StringIO()
+    err = io.StringIO()
+    sys.stdout = out
+    sys.stderr = err
+
+    argv = ['%s/' % (sphinx_docs_root,), str(html_docs_root), '-b', 'html', '-c', str(sphinx_docs_root)]
+
+    sphinx.cmd.build.main(argv)
+
+    out.seek(0)
+    err.seek(0)
+    return out.read(), err.read()
+
+
+async def build_docs(loop=None):
+    loop = loop or asyncio.get_event_loop()
+    with concurrent.futures.ProcessPoolExecutor() as pool:
+        try:
+            out, err = await loop.run_in_executor(pool, _run_sphinx_build)
+        except Exception:
+            logger.warning("Encountered problem while building documentation.", exc_info=True)
+
+        if "build succeeded" in out and err:
+            logger.info("Docs built successfully with the following warnings\n%s" % err)
+        elif "build succeeded" in out:
+            logger.info("Docs built successfully.")
+        else:
+            logger.warning("Unable to build docs:\n%s" % err)
 
 
 async def enable(services, loop=None):
     loop = loop if loop else asyncio.get_event_loop()
     html_docs_root.mkdir(parents=True, exist_ok=True)
-    loop.create_task(build_docs())
+    loop.create_task(build_docs(loop=loop))
     app_svc = services.get('app_svc')
     app_svc.application.router.add_route('GET', address, landing)
     app_svc.application.router.add_static('/docs/', str(html_docs_root.absolute()), append_version=True)


### PR DESCRIPTION
run sphinx directly from python instead of using sphinx-build and subprocess. 

The original way of doing this fails when sphinx-build isn't findable on PATH. 

This PR uses concurrent.futures.ProcessPoolExecutor to allow sphinx-build to run in a separate process without blocking the event loop.

resolves sphinx-build issue mentioned in https://github.com/mitre/caldera/issues/1817 