### PR TITLE
Fix wrong key spelling in LDAP example

### DIFF
--- a/sphinx-docs/Server-configuration.md
+++ b/sphinx-docs/Server-configuration.md
@@ -76,7 +76,7 @@ For example:
 ldap:
   dn: cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org
   server: ldap://ipa.demo1.freeipa.org
-  userattr: uid
+  user_attr: uid
   group_attr: objectClass
   red_group: organizationalperson
 ```


### PR DESCRIPTION
fix at least one of the minor issues but the one that caused most issue in the the waves of headaches that came in figuring out how to establish LDAP authentication with CALDERA. Very important for copy-pasters.