### PR TITLE
Fix container node skipped warnings from recommonmark

### DIFF
--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -3,11 +3,22 @@ import sys
 import pathlib
 
 import sphinx.ext.apidoc as apidoc
+from recommonmark.parser import CommonMarkParser
 
 caldera_root_dir = pathlib.Path('../../..').absolute()
 sys.path.insert(0, str(caldera_root_dir))
 
 from plugins.fieldmanual.utils.ability_csv import generate_ability_csv
+
+
+def visit_document(*_):
+    pass
+
+
+# Removes irrelevant warning messages during md file parsing.
+# REF: https://github.com/readthedocs/recommonmark/issues/177
+# Hopefully will be unnecessary in the future (when recommonmark > 0.6.0 exists)
+setattr(CommonMarkParser, 'visit_document', visit_document)
 
 
 # Call sphinx-apidoc to generate stub files from our source code.


### PR DESCRIPTION
Workaround for https://github.com/readthedocs/recommonmark/issues/177  