### PR TITLE
fixing error in documentation regarding API for /plugins/access/exploit

### DIFF
--- a/sphinx-docs/The-REST-API.md
+++ b/sphinx-docs/The-REST-API.md
@@ -32,7 +32,7 @@ curl -H "key:$API_KEY" -X POST localhost:8888/plugin/access/abilities -d '{"paw"
 
 Execute a given ability against an agent, outside the scope of an operation. 
 ```
-curl -H "key:ADMIN123" -X POST localhost:8888/plugin/access/exploit -d '{"paw":"$PAW","ability_id":"$ABILITY_ID"}'```
+curl -H "key:ADMIN123" -X POST localhost:8888/plugin/access/exploit -d '{"paw":"$PAW","ability_id":"$ABILITY_ID","obfuscator":"plain-text"}'
 ```
 > You can optionally POST an obfuscator and/or a facts dictionary with key/value pairs to fill in any variables the chosen ability requires.
 ```


### PR DESCRIPTION
According to this: https://github.com/mitre/access/blob/38dc328302d154e451ea0b5c7fa6e059322a2235/app/access_api.py#L30
The curl command requires 'obfuscator' as a field as well, which was missing in the documentation.

Resolves https://github.com/mitre/caldera/issues/1972#issuecomment-750444366