### PR TITLE
Removing pages from index which no longer exist

### DIFF
--- a/sphinx-docs/index.rst
+++ b/sphinx-docs/index.rst
@@ -25,8 +25,6 @@ If you're new to CALDERA, this is a good place to start.
    Objectives.md
    Initial-Access-Attacks.md
    Dynamically-Compiled-Payloads.md
-   Install-CALDERA-offline.md
-   Docker-deployment.md
    CALDERA-2.0.md
    Uninstalling-CALDERA.md
    Common-problems.md


### PR DESCRIPTION
Merged a few pages into the "Installing CALDERA" page in https://github.com/mitre/fieldmanual/pull/41, did not remove from the index.