### PR TITLE
Updated guide to match ability in stockpile

### DIFF
--- a/sphinx-docs/How-CALDERA-makes-decisions.md
+++ b/sphinx-docs/How-CALDERA-makes-decisions.md
@@ -7,10 +7,10 @@ Let's look at an example snippet of an ability that uses a parser:
     darwin:
       sh:
         command: |
-          find /Users -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' 2>/dev/null
+          find /Users -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' -size -500k 2>/dev/null | head -5
         parsers:
           plugins.stockpile.app.parsers.basic:
-            - source: host.file.sensitive
+            - source: host.file.path
               edge: has_extension
               target: file.sensitive.extension
 ```


### PR DESCRIPTION
## Description

This guide referenced the Find Files ability from stockpile, but the relationship source fact and commands were slightly mismatching. The example has been updated to accurately represent the referenced ability.

## Type of change

- [X] Documentation update

## How Has This Been Tested?

N/A

## Checklist:

- [N/A] My code follows the style guidelines of this project
- [N/A] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
