### PR TITLE
Virts 1733 Lateral Movement video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ htmlcov/
 .coverage.*
 *,cover
 _*/
+!_static/

--- a/sphinx-docs/Lateral-Movement-Guide.md
+++ b/sphinx-docs/Lateral-Movement-Guide.md
@@ -87,6 +87,8 @@ adversary profile. This section will assume successful setup from the previous s
 a 54ndc47 agent has been spawned with administrative privileges to the remote target host. The full ability files used 
 in this adversary profile are included at the end of this guide.
 
+See the a video of the following steps [here](#video-walkthrough).
+
 1. Go to `navigate` pane > `Advanced` > `sources`. This should open a new sources modal in the web GUI.
 2. Click the toggle to create a new source. Enter "SC Source" as the source name. Then enter `remote.host.fqdn` as the 
 fact trait and the FQDN of the target host you are looking to move laterally to as the fact value. Click `Save` once 
@@ -182,3 +184,15 @@ drop down, try refreshing the page.
           Start-Sleep -s 15;
           Get-Process -ComputerName #{remote.host.fqdn} s4ndc4t;
 ```  
+
+
+### Video Walkthrough
+
+Download video [here](./_static/lm_guide.mp4).
+
+<video width="700" height="450" controls>
+  <source src="./_static/lm_guide.mp4" type="video/mp4">
+Your browser does not support the video tag.
+</video>
+
+

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -53,6 +53,8 @@ extensions = [
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+html_static_path = ['_static']
+
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'

--- a/sphinx-docs/resources.rst
+++ b/sphinx-docs/resources.rst
@@ -7,3 +7,16 @@ Ability List
 The following file contains a list of Caldera's abilities in comma-separated value (CSV) format.
 
 :download:`abilities.csv <_generated/abilities.csv>`
+
+
+Lateral Movement Video Tutorial
+===============================
+
+Download from here: :download:`lm_guide.mp4 <./_static/lm_guide.mp4>`
+
+.. raw:: html
+
+    <video width="700" height="450" controls>
+      <source src="./_static/lm_guide.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+    </video>


### PR DESCRIPTION
## Description

Adds a bundled video showing a walkthrough of the lateral movement guide. 

This tests out if we can directly bundle **small** videos in the documentation without needing to have them served from YouTube. 


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Started caldera locally and verified that that embedded video did work on Chrome/Firefox. 

We should get someone with admin access to the caldera readthedocs project to run a test build before merging (unsure if there will be issues with including the ~8 MB video file). 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
