### PR TITLE
[VIRTS-1970] Don't load ability files under data/backup 

### DIFF
--- a/sphinx-docs/Server-Configuration.md
+++ b/sphinx-docs/Server-Configuration.md
@@ -5,7 +5,10 @@
 `server.py` supports the following arguments:
 
 - `--log {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: Sets the log option. The `DEBUG` option is useful for troubleshooting.
-- `--fresh`: Deletes all non-plugin data including custom abilities and adversaries, operations, and the agent list.
+- `--fresh`: Resets all non-plugin data including custom abilities and adversaries, operations, and the agent list.
+  This is accomplished by moving all non-plugin data to a `<caldera_root>/data/backup` directory. The contents of
+  this directory are cleared before moving files into it. This makes it possible to recover the server state after an
+  accidental `--fresh` startup by running `cp -R <caldera_root>/data/backup/ <caldera_root>/` before server startup.
 - `--environment ENVIRONMENT`: Sets a custom configuration file. See "Custom configuration files" below for additional details.
 - `--plugins PLUGINS`: Sets CALDERA to run only with the specified plugins
 - `--insecure`: Uses the `conf/default.yml` file for configuration, not recommended.


### PR DESCRIPTION
## Description
Related: https://github.com/mitre/caldera/pull/2101

The behavior of starting caldera with `--fresh` is being changed to move files under a `data/backup` directory rather than deleting them outright. This PR changes the ability-discovery behavior of fieldmanual to ignore the `data/backup` folder as these are "deleted" files.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I ran `make html` in the sphinx directory and confirmed that it ignored my backup directory (which had invalid ability files that were causing parser errors originally).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
