### PR TITLE
[VIRTS-1970] Update --fresh documentation (round two)

### DIFF
--- a/sphinx-docs/Server-Configuration.md
+++ b/sphinx-docs/Server-Configuration.md
@@ -6,9 +6,9 @@
 
 - `--log {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: Sets the log option. The `DEBUG` option is useful for troubleshooting.
 - `--fresh`: Resets all non-plugin data including custom abilities and adversaries, operations, and the agent list.
-  This is accomplished by moving all non-plugin data to a `<caldera_root>/data/backup` directory. The contents of
-  this directory are cleared before moving files into it. This makes it possible to recover the server state after an
-  accidental `--fresh` startup by running `cp -R <caldera_root>/data/backup/ <caldera_root>/` before server startup.
+  A gzipped, tarball backup of the original content is stored in the `data/backup` directory. This makes it possible to 
+  recover the server state after an accidental `--fresh` startup by running `tar -zxvf data/backup/backup-<timestamp>.tar.gz`
+  from the root caldera directory before server startup.
 - `--environment ENVIRONMENT`: Sets a custom configuration file. See "Custom configuration files" below for additional details.
 - `--plugins PLUGINS`: Sets CALDERA to run only with the specified plugins
 - `--insecure`: Uses the `conf/default.yml` file for configuration, not recommended.

--- a/utils/ability_csv.py
+++ b/utils/ability_csv.py
@@ -51,9 +51,7 @@ def generate_ability_csv(caldera_dir, dest_file="abilities.csv"):
         writer = csv.DictWriter(fle, fieldnames=OUTPUT_COLUMNS)
         writer.writeheader()
         for i, ability_file in enumerate(caldera_path.glob("**/abilities/*/*.yml")):
-            # Running caldera with --fresh moves data files (including ability files)
-            # into a backup directory. We don't want those "removed" ability files
-            # to be discovered by fieldmanual.
+            # Skip the backup directory in case someone opened up backup tar.gz file in there.
             if str(ability_file).startswith(caldera_data_backup_path):
                 continue
 


### PR DESCRIPTION
## Description
Related: #73 

We changes the `--fresh` behavior in caldera core to make a gzipped tarball file rather than moving files into the `data/backup` directory. This PR updates the sphinx documentation to reflect the new convention.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I reviewed the rendered markdown.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
