### PR TITLE
UDP protocol arg in docker run

### DIFF
--- a/sphinx-docs/Installing-CALDERA.md
+++ b/sphinx-docs/Installing-CALDERA.md
@@ -56,7 +56,7 @@ docker build . -t caldera:server
 Finally, run the docker CALDERA server:
 
 ```
-docker run -p 7010:7010 -p 7011:7011 -p 7012:7012 -p 8888:8888 caldera:server
+docker run -p 7010:7010 -p 7011:7011/udp -p 7012:7012 -p 8888:8888 caldera:server
 ```
 
 ## Offline Installation


### PR DESCRIPTION
## Description

The docker deployment documentation contained a minor bug where port 7011 was published for TCP (default) but not for the UDP protocol.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally using docker run.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
