### PR TITLE
[VIRTS-2186] Add documentation on stopping the CALDERA server

### DIFF
--- a/sphinx-docs/Troubleshooting.md
+++ b/sphinx-docs/Troubleshooting.md
@@ -8,6 +8,10 @@
 1. Run the CALDERA server with the `--log DEBUG` parameter to see if there is additional output.
 1. Consider removing the `conf/local.yml` and letting CALDERA recreate the file when the server runs again.
 
+## Stopping CALDERA
+
+CALDERA has a backup, cleanup, and save procedure that runs when the key combination `CTRL+C` is pressed. This is the recommended method to ensure proper shutdown of the server. If the Python process executing CALDERA is halted abruptly (for example SIGKILL) it can cause information from plugins to get lost or configuration settings to not reflect on a server restart. 
+
 ## Agent Deployment
 
 ### Downloading the agent


### PR DESCRIPTION
## Description

Add a note about stopping CALDERA correctly to prevent data loss. 

## Type of change

- [X] This change requires a documentation update

## How Has This Been Tested?

Found during training, it affects all plugins since abruptly stopping the process will not allow pending changes and configuration to be serialized, backed-up, etc. After correctly shutting down the server, I was able to keep my progress and advance in the certification.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
