### PR TITLE
Replacing example link IDs with UUID strings

### DIFF
--- a/sphinx-docs/How-to-Build-Agents.md
+++ b/sphinx-docs/How-to-Build-Agents.md
@@ -144,18 +144,18 @@ agent's profile. The following section explains how lateral movement tracking ha
 
 ### 54ndc47
 
-An example 54ndc47 spawn command has been copied from the (Service Creation ability)[https://github.com/mitre/stockpile/blob/master/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml]
+An example 54ndc47 spawn command has been copied from the [Service Creation ability](https://github.com/mitre/stockpile/blob/master/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml)
 and included below for reference:
 ```
 C:\Users\Public\s4ndc4t.exe -server #{server} -originLinkID #{origin_link_id}
 ```
-If the CALDERA server is running on `http://192.168.0.1:8888` and the ID of the Link with the spawn command is `123456`,
+If the CALDERA server is running on `http://192.168.0.1:8888` and the ID of the Link with the spawn command is `cd63fdbb-0f3a-49ea-b4eb-306a3ff40f81`,
 the populated command will appear as:
 ```
-C:\Users\Public\s4ndc4t.exe -server http://192.168.0.1:8888 -originLinkID 123456
+C:\Users\Public\s4ndc4t.exe -server http://192.168.0.1:8888 -originLinkID cd63fdbb-0f3a-49ea-b4eb-306a3ff40f81
 ```
 The 54ndc47 agent stores the value of this global variable in its profile, which is then returned to the CALDERA server
-upon first check-in as a key\value pair `origin_link_id : 123456` in the JSON dictionary. The CALDERA server will 
+upon first check-in as a key\value pair `origin_link_id : cd63fdbb-0f3a-49ea-b4eb-306a3ff40f81` in the JSON dictionary. The CALDERA server will 
 automatically store this pair when creating the Agent object and use it when generating the Attack Path graph in the
 Debrief plugin.
 

--- a/sphinx-docs/Operation-Results.md
+++ b/sphinx-docs/Operation-Results.md
@@ -118,7 +118,7 @@ Below is an example operation report JSON:
       "pending_contact": "HTTP",
       "ppid": 2624,
       "sleep_min": 5,
-      "origin_link_id": 0,
+      "origin_link_id": "",
       "host": "WORKSTATION1",
       "trusted": true,
       "group": "red",


### PR DESCRIPTION
## Description
Replace integers with UUID strings when using link IDs for origin_link_id.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Reloaded the documentation and made sure it appears correctly.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
