### PR TITLE
ModuleNotFound Troubleshooting addition

### DIFF
--- a/sphinx-docs/Troubleshooting.md
+++ b/sphinx-docs/Troubleshooting.md
@@ -8,6 +8,15 @@
 1. Run the CALDERA server with the `--log DEBUG` parameter to see if there is additional output.
 1. Consider removing the `conf/local.yml` and letting CALDERA recreate the file when the server runs again.
 
+### Module Not Found Error
+
+If you get an error like `ModuleNotFoundError: No module named 'plugins.manx.app'` when starting CALDERA:
+1. Check to see if the `plugins/manx` folder is empty
+   1. Ensure that CALDERA has been cloned recursively. Plugins are stored in submodules and must be cloned along with the core code.
+   1. Alternatively, from the plugins folder, you can run `git clone https://github.com/mitre/manx.git` to grab only the manx repo.
+1. Check your `conf/local.yml` to make sure manx is enabled
+
+
 ## Stopping CALDERA
 
 CALDERA has a backup, cleanup, and save procedure that runs when the key combination `CTRL+C` is pressed. This is the recommended method to ensure proper shutdown of the server. If the Python process executing CALDERA is halted abruptly (for example SIGKILL) it can cause information from plugins to get lost or configuration settings to not reflect on a server restart. 


### PR DESCRIPTION
## Description

Add a section to the Troubleshooting documentation regarding the `ModuleNotFoundError: No module named 'plugins.manx.app'` error that has come up several times in the github issues. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Ran caldera to see the changes reflected in Fieldmanual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
