### PR TITLE
Fix stale reference to "What is an ability" section

### DIFF
--- a/sphinx-docs/Lateral-Movement-Guide.md
+++ b/sphinx-docs/Lateral-Movement-Guide.md
@@ -75,7 +75,7 @@ host, which moved laterally to the `VAGRANTDC` machine via successful execution 
 
 This capability relies on the `origin_link_id` field to be populated within the agent profile upon first
 check-in and is currently implemented for the default agent, Sandcat. For more information about the `#{origin_link_id}`
-global variable, see the explanation of **Command** in the [Ability](Basic-Usage.md#abilities)
+global variable, see the explanation of **Command** in the [Abilities](Basic-Usage.md#abilities)
 section of the Basic Usage guide. For more information about how lateral movement tracking is implemented 
 in agents to be used with CALDERA, see the [Lateral Movement Tracking](How-to-Build-Agents.md#lateral-movement-tracking) 
 section of the How to Build Agents guide.

--- a/sphinx-docs/Lateral-Movement-Guide.md
+++ b/sphinx-docs/Lateral-Movement-Guide.md
@@ -75,8 +75,8 @@ host, which moved laterally to the `VAGRANTDC` machine via successful execution 
 
 This capability relies on the `origin_link_id` field to be populated within the agent profile upon first
 check-in and is currently implemented for the default agent, Sandcat. For more information about the `#{origin_link_id}`
-global variable, see the explanation of **Command** in the [What is an Ability?](Learning-the-terminology.md#abilities-and-adversaries)
-section of the Learning the Terminology guide. For more information about how lateral movement tracking is implemented 
+global variable, see the explanation of **Command** in the [Ability](Basic-Usage.md#abilities)
+section of the Basic Usage guide. For more information about how lateral movement tracking is implemented 
 in agents to be used with CALDERA, see the [Lateral Movement Tracking](How-to-Build-Agents.md#lateral-movement-tracking) 
 section of the How to Build Agents guide.
 


### PR DESCRIPTION
## Description

I noticed that the link to the with more information about `origin_link_id` reference the an old, outdated version of documentation (https://caldera.readthedocs.io/en/2.8.0/Learning-the-terminology.html). The PR updates the reference to the current documentation layout. 

## Type of change

- [x] Documentation update

## How Has This Been Tested?

Viewed updated documentation and confirmed link and text are correct

## Checklist:
- [x] I have performed a self-review of my own code


