### PR TITLE
[VIRTS-4155] Updated documentation to account for Exit Codes in Sandcat / Agents

### DIFF
--- a/sphinx-docs/How-to-Build-Agents.md
+++ b/sphinx-docs/How-to-Build-Agents.md
@@ -100,7 +100,7 @@ Looking at the previous response, you can see each instruction contains:
 Now, you'll want to revise your agent to loop through all the instructions, executing each command
 and POSTing the response back to the /beacon endpoint. You should pause after running each instruction, using the sleep time provided inside the instruction.
 ```
-data=$(echo '{"paw":"$paw","results":[{"id":$id, "output":$output, "stderr":$stderr, "status": $status, "pid":$pid}]}' | base64)
+data=$(echo '{"paw":"$paw","results":[{"id":$id, "output":$output, "stderr":$stderr, "exit_code":$exit_code, "status": $status, "pid":$pid}]}' | base64)
 curl -s -X POST -d $data localhost:8888/beacon
 sleep $instruction_sleep
 ```
@@ -110,6 +110,7 @@ The POST details inside the result are as follows:
 * **id**: the ID of the instruction you received
 * **output**: the base64 encoded output (or stdout) from running the instruction
 * **stderr**: the base64 encoded error messages (or stderr) from running the instruction
+* **exit_code**: the OS or process exit code from running the instruction.  If unsure, leave blank. 
 * **status**: the status code from running the instruction. If unsure, put 0.
 * **pid**: the process identifier the instruction ran under. If unsure, put 0.
 

--- a/sphinx-docs/Operation-Results.md
+++ b/sphinx-docs/Operation-Results.md
@@ -31,6 +31,7 @@ The operation report JSON consists of a single dictionary with the following key
     - `output`: optional field. JSON dict containing the output generated when running the command. Only appears if the user selected the `include agent output` option when downloading the report.
         - `stdout`: Standard output from the command that was run.
         - `stderr`: Standard error from the command that was run.
+        - `exit_code`: Exit code returned from the command that was run.
 - `finish`: Timestamp string in YYYY-MM-DD HH:MM:SS format that indicates when the operation finished.
 - `planner`: Name of the planner used for the operation.
 - `adversary`: JSON dict containing information about the adversary used in the operation
@@ -350,7 +351,8 @@ Below is an example operation report JSON:
           "jitter": 0,
           "output": {
             "stdout": "False",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "paw": "vrgirx",
           "pid": "14441",
@@ -428,7 +430,8 @@ Below is an example operation report JSON:
           "name": "Create staging directory",
           "output": {
             "stdout": "/Users/foo/staged",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 56272,
           "platform": "darwin",
@@ -451,7 +454,8 @@ Below is an example operation report JSON:
           "name": "Find files",
           "output": {
             "stdout": "/Users/foo/bar/PyTorch\\ Models/myModel.pt",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 56376,
           "platform": "darwin",
@@ -474,7 +478,8 @@ Below is an example operation report JSON:
           "name": "Find files",
           "output": {
             "stdout": "/Users/foo/bar/credentials.yml",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 56562,
           "platform": "darwin",
@@ -497,7 +502,8 @@ Below is an example operation report JSON:
           "name": "Find files",
           "output": {
             "stdout": "/Users/foo/bar/sensitive.sql",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 56809,
           "platform": "darwin",
@@ -521,6 +527,7 @@ Below is an example operation report JSON:
           "output": {
             "stdout": "",
             "stderr": "cp: /Users/foo/bar/PyTorch\\ Models/myModel.pt: No such file or directory"
+            "exit_code": "1",
           },
           "pid": 57005,
           "platform": "darwin",
@@ -581,7 +588,8 @@ Below is an example operation report JSON:
           "name": "Compress staged directory",
           "output": {
             "stdout": "/Users/foo/staged.tar.gz",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 57383,
           "platform": "darwin",
@@ -604,7 +612,8 @@ Below is an example operation report JSON:
           "name": "Exfil staged directory",
           "output": {
             "stdout": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                 Dload  Upload   Total   Spent    Left  Speed\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1357    0     0  100  1357      0   441k --:--:-- --:--:-- --:--:--  441k",
-            "stderr": ""
+            "stderr": "",
+            "exit_code": "0"
           },
           "pid": 57568,
           "platform": "darwin",
@@ -697,6 +706,7 @@ The event dictionary has the following keys and values:
 - `output`: if the user selected `include agent output` when downloading the operation event logs, this field will contain a dictionary of the agent-provided output from running the link command.
     - `stdout`
     - `stderr`
+    - `exit_code`
 - `agent_reported_time`: Timestamp string representing the time at which the execution was ran by the agent in YYYY-MM-DD HH:MM:SS format. This field will not be present if the agent does not support reporting the command execution time.
 
 Below is a sample output for operation event logs:
@@ -861,7 +871,8 @@ Below is a sample output for operation event logs:
     },
     "output": {
       "stdout": "C:\\Users\\carlomagno\\staged",
-      "stderr": ""
+      "stderr": "",
+      "exit_code": "0"
     },
     "agent_reported_time": "2021-02-23T11:50:33Z"
   },

--- a/sphinx-docs/Operation-Results.md
+++ b/sphinx-docs/Operation-Results.md
@@ -526,8 +526,8 @@ Below is an example operation report JSON:
           "name": "Stage sensitive files",
           "output": {
             "stdout": "",
-            "stderr": "cp: /Users/foo/bar/PyTorch\\ Models/myModel.pt: No such file or directory"
-            "exit_code": "1",
+            "stderr": "cp: /Users/foo/bar/PyTorch\\ Models/myModel.pt: No such file or directory",
+            "exit_code": "1"
           },
           "pid": 57005,
           "platform": "darwin",

--- a/sphinx-docs/Plugin-library.md
+++ b/sphinx-docs/Plugin-library.md
@@ -79,6 +79,23 @@ communication via SMB named pipes).
 See https://github.com/TheWover/donut for additional information.
 - `shared` extension provides the C sharing functionality for Sandcat.
 
+#### Exit Codes
+
+Exit codes returned from Sandcat vary across executors. Typical shell executors will return the exit code provided by the shell. Certain executor extensions will return values hard-coded in Sandcat.
+
+Sandcat includes general exit codes which may be utilized by executors, overriden by executors, or used in error cases. The following values describe general Sandcat exit codes:
+- `-1`: Error (e.g., cannot decode command, payload not available)
+- `0`: Success
+
+The following values describe exit codes utilized by specific executors:
+- `shells`: Returns the exit code provided by the OS/shell.
+- `shellcode`: Utilizes the general Sandcat exit codes.
+- `native` and `native_aws`:
+    - `0`: Success
+    - `1`: Process error (e.g., error while executing code)
+    - `2`: Input error (e.g., invalid parameters)
+- `donut`: Returns the exit code provided by the OS/shell.
+
 #### Customizing Default Options & Execution Without CLI Options
 
 It's possible to customize the default values of these options when pulling Sandcat from the CALDERA server.  


### PR DESCRIPTION
## Description

Update documentation to account for Sandcat (and potentially other agents) returning exit codes.  Dependent on Sandcat PR (https://github.com/mitre/sandcat/pull/427) and server PR (https://github.com/mitre/caldera/pull/2713)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Updated documentation, ran the server, and verified the documents updated in the GUI.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
