### PR TITLE
Added alt_command and labels to ability documentation

### DIFF
--- a/sphinx-docs/Basic-Usage.md
+++ b/sphinx-docs/Basic-Usage.md
@@ -69,6 +69,11 @@ Here is a sample ability:
       sh:
         command: |
           ./wifi.sh scan
+        alt_command:
+          './wifi.sh modify'
+        labels:
+          - scan
+          - modify
         payload: wifi.sh
     windows:
       psh:
@@ -98,6 +103,8 @@ Each platform block consists of a:
 * parsers (optional)
 * requirements (optional)
 * timeout (optional)
+* alt_command (optional)
+* labels (optional)
 
 **Command**: A command can be 1-line or many and should contain the code you would like the ability to execute. Newlines in the command will be deleted before execution. The command can (optionally) contain variables, which are identified as `#{variable}`.
 
@@ -165,6 +172,10 @@ Abilities can also make use of two CALDERA REST API endpoints, file upload and d
 **Requirements**: Required relationships of facts that need to be established before this ability can be used. See [Requirements](Requirements.md) for more information.
 
 **Timeout**: How many seconds to allow the command to run.
+
+**Alt Command**: A second command listed in the same ability. This generates a "toggle" UI element which lets a user switch between 'command' and 'alt_command' within the same ability choice. This is recommended for abilities which accomplish similar goals but have different commands that may be confusing or require a great deal of documentation to explain. 
+
+**Labels**: A list of 2 strings that are the labels for the toggle added by the Alt Command field.
 
 ### Bootstrap and Deadman Abilities 
 


### PR DESCRIPTION
## Description

Documentation for mjr-dev branch of caldera - Adds alt_command, labels to ability description for alt_command toggle in operations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Mostly manual tests - would need advisement on UI element testing


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
