### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/sphinx-docs/Installing-CALDERA.md
+++ b/sphinx-docs/Installing-CALDERA.md
@@ -7,7 +7,7 @@ CALDERA can be installed in four commands using the [concise installation instru
 CALDERA aims to support a wide range of target systems, the core requirements are listed below:
 
 * Linux or MacOS operating system
-* Python 3.7, 3.8, or 3.9 (with pip3)
+* Python 3.8 or later (with pip3)
 * A modern browser (Google Chrome is recommended)
 * The packages listed in the [requirements file](https://github.com/mitre/caldera/blob/master/requirements.txt)
 

--- a/sphinx-docs/Server-Configuration.md
+++ b/sphinx-docs/Server-Configuration.md
@@ -62,7 +62,7 @@ requirements:  # CALDERA requirements
     attr: version
     module: sys
     type: python_module
-    version: 3.7.0
+    version: 3.8.0
 users:  # User list for CALDERA blue and CALDERA red
   blue:
     blue: admin  # Username and password

--- a/sphinx-docs/Troubleshooting.md
+++ b/sphinx-docs/Troubleshooting.md
@@ -10,7 +10,7 @@ If `donut-shellcode` installation fails, ensure that prerequisite packages are i
 ## Starting CALDERA
 
 1. Ensure that CALDERA has been cloned recursively. Plugins are stored in submodules and must be cloned along with the core code.
-1. Check that Python 3.7+ is installed and being used. 
+1. Check that Python 3.8+ is installed and being used. 
 1. Confirm that all `pip` requirements have been fulfilled.
 1. Run the CALDERA server with the `--log DEBUG` parameter to see if there is additional output.
 1. Consider removing the `conf/local.yml` and letting CALDERA recreate the file when the server runs again.
@@ -26,7 +26,7 @@ If you get an error like `ModuleNotFoundError: No module named 'plugins.manx.app
 
 ## Stopping CALDERA
 
-CALDERA has a backup, cleanup, and save procedure that runs when the key combination `CTRL+C` is pressed. This is the recommended method to ensure proper shutdown of the server. If the Python process executing CALDERA is halted abruptly (for example SIGKILL) it can cause information from plugins to get lost or configuration settings to not reflect on a server restart. 
+CALDERA has a backup, cleanup, and save procedure that runs when the key combination `CTRL+C` is pressed. This is the recommended method to ensure proper shutdown of the server. If the Python process executing CALDERA is halted abruptly (for example SIGKILL) it can cause information from plugins to get lost or configuration settings to not reflect on a server restart.
 
 ## Agent Deployment
 


### PR DESCRIPTION
## Description

Python 3.7 has reached end of life and is no longer officially supported. We're dropping 3.7 support so need to update mentions of minimum required Python version.

## Type of change

- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
