### PR TITLE
Feature: Caldera Command Syntax Highlighting

### DIFF
--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -3,13 +3,15 @@ import pathlib
 import sys
 
 import sphinx.ext.apidoc as apidoc
+from sphinx.highlighting import lexers
+
 
 caldera_root_dir = pathlib.Path('../../..').absolute()
 sys.path.insert(0, str(caldera_root_dir))
 
 from plugins.fieldmanual.utils.plugin_docs import import_plugin_docs
 from plugins.fieldmanual.utils.ability_csv import generate_ability_csv
-
+from plugins.fieldmanual.utils.command_lexer import CalderaCommandLexer
 
 def visit_document(*_):
     pass
@@ -47,6 +49,8 @@ extensions = [
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_static_path = ['_static']
+
+lexers['caldera'] = CalderaCommandLexer()
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/utils/command_lexer.py
+++ b/utils/command_lexer.py
@@ -1,0 +1,31 @@
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import Keyword, Literal, Name, Punctuation, Whitespace, Text
+
+
+class CalderaCommandLexer(RegexLexer):
+    name = "CalderaCommand"
+    aliases = ["caldera"]
+    filenames = []
+
+    tokens = {
+        "root": [
+            # Match the executable
+            (r"(?:\./|\.\\)[\w-]+(?:\.[\w]+)?", Name.Function),
+
+            # Match the #{fact} pattern
+            (r"(\#\{)([^\}]+)(\})", bygroups(Punctuation, Keyword, Punctuation)),
+
+            # Match command line flags
+            (r"(-{1,2}[\w]+(?:-[\w]+)*=?)([\w\.\-]+)?", bygroups(Name.Variable, Literal.String)),
+
+            (r'"([^"]*)"', Literal.String),
+            (r"'([^']*)'", Literal.String),
+            (r"[\w]+(?:-[\w]+)*", Literal.String),
+
+            (r"\b\d+(\.\d+)?\b", Literal.Number),
+
+            (r"\s+", Whitespace),
+
+            (r".", Text),
+        ],
+    }

--- a/utils/command_lexer.py
+++ b/utils/command_lexer.py
@@ -10,7 +10,7 @@ class CalderaCommandLexer(RegexLexer):
     tokens = {
         "root": [
             # Match the executable
-            (r"(?:\./|\.\\)[\w-]+(?:\.[\w]+)?", Name.Function),
+            (r'(?:\./|\.\\)(?:[\w-]+(?:/[\w-]+)*/?)(?:[\w-]+(?:\.[\w]+)?)', Name.Function),
 
             # Match the #{fact} pattern
             (r"(\#\{)([^\}]+)(\})", bygroups(Punctuation, Keyword, Punctuation)),


### PR DESCRIPTION
## Description

Adds a lexer to highlight common command line syntaxes including Caldera fact templates.

Before 😭 
<img width="728" alt="Screenshot 2024-12-07 at 2 53 13 PM" src="https://github.com/user-attachments/assets/8af620d5-e706-4bd9-9ad4-5061b33e977e">

After 🥳 
<img width="731" alt="Screenshot 2024-12-07 at 2 52 57 PM" src="https://github.com/user-attachments/assets/e208cf7e-6468-4f87-93ae-e8b2c427df35">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

"Unit" testing with a range of expected command strings. These tests were far from exhaustive, but the fallback behavior of the lexer is to treat any unmatched characters as simple text.

"Integration" testing by adding to a local instance of Caldera (v5.0) and starting the server.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
