### PR TITLE
Fix copilot review feedback on functional tests

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,13 +2,10 @@
 
 Tests cover:
 - hook.py syntax validation via ast.parse
-- Abilities YAML validation (if present)
-- Requirements.txt dependency checks (if present)
 - Security pattern scanning across Python source files
 """
 import ast
 import os
-import glob
 import re
 
 import pytest
@@ -22,7 +19,7 @@ class TestHookSyntax:
     def test_hook_parses(self):
         """hook.py should be valid Python syntax."""
         hook_path = os.path.join(PLUGIN_DIR, "hook.py")
-        with open(hook_path, "r") as fh:
+        with open(hook_path, "r", encoding="utf-8") as fh:
             source = fh.read()
         tree = ast.parse(source, filename="hook.py")
         assert isinstance(tree, ast.Module)
@@ -30,7 +27,7 @@ class TestHookSyntax:
     def test_hook_has_no_bare_exec(self):
         """hook.py should not contain bare exec() calls."""
         hook_path = os.path.join(PLUGIN_DIR, "hook.py")
-        with open(hook_path, "r") as fh:
+        with open(hook_path, "r", encoding="utf-8") as fh:
             source = fh.read()
         tree = ast.parse(source)
         for node in ast.walk(tree):
@@ -47,7 +44,7 @@ class TestHookSyntax:
                 if not fname.endswith(".py"):
                     continue
                 fpath = os.path.join(root, fname)
-                with open(fpath, "r") as fh:
+                with open(fpath, "r", encoding="utf-8") as fh:
                     source = fh.read()
                 try:
                     ast.parse(source, filename=fname)
@@ -73,7 +70,7 @@ class TestSecurityPatterns:
     def test_no_verify_false(self):
         """No Python file should use verify=False (disables TLS verification)."""
         for fpath in self._py_files():
-            with open(fpath, "r") as fh:
+            with open(fpath, "r", encoding="utf-8") as fh:
                 for lineno, line in enumerate(fh, 1):
                     if "verify=False" in line and not line.strip().startswith("#"):
                         rel = os.path.relpath(fpath, PLUGIN_DIR)
@@ -88,7 +85,7 @@ class TestSecurityPatterns:
             fname = os.path.basename(fpath)
             if any(fname.startswith(a) or fname == a for a in allowlist):
                 continue
-            with open(fpath, "r") as fh:
+            with open(fpath, "r", encoding="utf-8") as fh:
                 for lineno, line in enumerate(fh, 1):
                     stripped = line.strip()
                     if stripped.startswith("#"):
@@ -103,13 +100,13 @@ class TestSecurityPatterns:
         """requests.get/post/put/delete calls should include a timeout parameter."""
         pattern = re.compile(r"requests\.(get|post|put|delete|patch|head)\(")
         for fpath in self._py_files():
-            with open(fpath, "r") as fh:
+            with open(fpath, "r", encoding="utf-8") as fh:
                 source = fh.read()
             for match in pattern.finditer(source):
                 start = match.start()
                 depth = 0
                 end = start
-                for i in range(start, min(start + 500, len(source))):
+                for i in range(start, len(source)):
                     if source[i] == "(":
                         depth += 1
                     elif source[i] == ")":


### PR DESCRIPTION
## Summary
- Remove inaccurate docstring claims about YAML/requirements checks
- Remove unused `glob` import
- Remove arbitrary 500-char window limit in regex call scanning
- Add `encoding='utf-8'` to all `open()` calls

## Test plan
- [ ] Run `pytest tests/test_functional.py` to verify tests still pass